### PR TITLE
fix: Systems were ran with task.spawn

### DIFF
--- a/crates/sapphire-jecs/lib/init.luau
+++ b/crates/sapphire-jecs/lib/init.luau
@@ -6,7 +6,6 @@ local RunService = game:GetService("RunService")
 local is_client = RunService:IsClient()
 
 local jabby = require(script.Parent.jabby)
-local fast_spawn = require(script.Parent.spawn)
 local jecs = require(script.Parent.jecs)
 --- An i53, can be represented with an f64.
 export type i53 = number
@@ -125,7 +124,7 @@ function SapphireJecs.extension()
                 end
 
                 jabby_scheduler:_mark_system_frame_start(id)
-                fast_spawn(system.run, ...)
+                system.run(...)
                 jabby_scheduler:_mark_system_frame_end(id)
             end
         end

--- a/crates/sapphire-jecs/wally.toml
+++ b/crates/sapphire-jecs/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mark-marks/sapphire-jecs"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 license = "MIT"
@@ -16,7 +16,5 @@ include = [
 
 [dependencies]
 jecs_utils = "mark-marks/jecs-utils@0.1.5"
-signal = "red-blox/signal@2.0.2"
-spawn = "red-blox/spawn@1.1.0"
 jecs = "ukendio/jecs@0.3.2"
 jabby = "alicesaidhi/jabby@0.2.0-rc.2"


### PR DESCRIPTION
Systems were ran with a fast spawn implementation (so `task.spawn`) which meant the time they took wasn't accurately measured by jabby